### PR TITLE
fix: convert switchToEdit to none

### DIFF
--- a/src/utils/__tests__/conversion.spec.js
+++ b/src/utils/__tests__/conversion.spec.js
@@ -15,6 +15,10 @@ describe('conversion', () => {
       const result = convertNavigation('gotoStory');
       expect(result).to.equal('goToStory');
     });
+    it('should return none for switchToEdit', () => {
+      const result = convertNavigation('switchToEdit');
+      expect(result).to.equal('none');
+    });
     it('should return default entry', () => {
       const result = convertNavigation('myOldType');
       expect(result).to.equal('myOldType');

--- a/src/utils/conversion.js
+++ b/src/utils/conversion.js
@@ -39,6 +39,8 @@ export function convertNavigation(oldType) {
       return 'goToSheetById';
     case 'gotoStory':
       return 'goToStory';
+    case 'switchToEdit':
+      return 'none';
     default:
       return oldType;
   }


### PR DESCRIPTION
Assuming we need to remove it?