### PR TITLE
fix: undo results in empty label

### DIFF
--- a/src/ext.js
+++ b/src/ext.js
@@ -255,6 +255,7 @@ export default function ext({ translator }) {
                 label: {
                   component: 'string',
                   ref: 'style.label',
+                  defaultValue: '',
                   translation: 'Common.Label',
                   expression: 'optional',
                 },


### PR DESCRIPTION
For some reason undo does not result back in the default label set at creation of the button object but to null value. Setting empty string as default value will make sure that undo will set to empty string instead of a null. 