### PR TITLE
fix: sanity check for correct label + test updates

### DIFF
--- a/src/__tests__/default-button-props.js
+++ b/src/__tests__/default-button-props.js
@@ -1,12 +1,12 @@
 import props from '../object-properties';
 
-const defaultValues = (sandbox) => ({
+const defaultValues = sandbox => ({
   theme: {
     getDataColorSpecials: () => ({ primary: 'myPrimaryColor' }),
     getColorPickerColor: sandbox ? sandbox.stub() : () => '',
     getStyle: sandbox ? sandbox.stub() : () => '',
   },
-  layout: { style: props.style },
+  layout: { style: JSON.parse(JSON.stringify(props.style)) },
   element: {
     firstElementChild: {
       setAttribute: () => {},

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -218,15 +218,13 @@ describe('style-formatter', () => {
 
   describe('createLabelAndIcon', () => {
     let theme;
-    let layout;
     let button;
     let style;
 
     beforeEach(() => {
       const d = defaultValues(sandbox);
       theme = d.theme;
-      layout = d.layout;
-      style = layout.style;
+      style = d.layout.style;
 
       button = {
         firstElementChild: { setAttribute: sinon.spy(), offsetHeight: 400, offsetWidth: 20 },
@@ -278,9 +276,7 @@ describe('style-formatter', () => {
     });
 
     it('should set fontSize when italic is selected', () => {
-      style.font.style = {
-        italic: true,
-      };
+      style.font.style.italic = true;
       button.appendChild = child => {
         child.setAttribute = sinon.spy();
         child.offsetHeight = 400;
@@ -294,23 +290,24 @@ describe('style-formatter', () => {
     it('should place icon first then label inside text element', () => {
       const isSense = true;
       style.icon.useIcon = true;
-      style.icon.iconType = 'someIcon';
+      style.icon.iconType = 'back';
       styleFormatter.createLabelAndIcon({ theme, button, style, isSense });
       const text = button.children[0];
       expect(text.children[0].style.textDecoration).to.equal('none');
       expect(text.children[1].textContent).to.equal('Button');
-      expect(button.children[0].style.fontSize).to.equal('10.5px');
+      expect(button.children[0].style.fontSize).to.equal('11px');
     });
 
     it('should place label first then icon inside text element', () => {
       const isSense = true;
       style.icon.useIcon = true;
-      style.icon.iconType = 'someIcon';
+      style.icon.iconType = 'Back';
       style.icon.position = 'right';
       styleFormatter.createLabelAndIcon({ theme, button, style, isSense });
       const text = button.children[0];
       expect(text.children[0].textContent).to.equal('Button');
       expect(text.children[1].style.textDecoration).to.equal('none');
+      expect(button.children[0].style.fontSize).to.equal('11px');
     });
 
     it('should set textDecoration to underline', () => {

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -93,7 +93,7 @@ describe('style-formatter', () => {
     });
 
     it('should return font-style: italic when italic is selected', () => {
-      style.font.style = {
+      style.font.style.italic = {
         italic: true,
       };
       const formattedStyle = styleFormatter.getStyles({ style, disabled, theme });
@@ -276,7 +276,9 @@ describe('style-formatter', () => {
     });
 
     it('should set fontSize when italic is selected', () => {
-      style.font.style.italic = true;
+      style.font.style.italic = {
+        italic: true,
+      };
       button.appendChild = child => {
         child.setAttribute = sinon.spy();
         child.offsetHeight = 400;
@@ -288,6 +290,9 @@ describe('style-formatter', () => {
     });
 
     it('should place icon first then label inside text element', () => {
+      style.font.style.italic = {
+        italic: true,
+      };
       const isSense = true;
       style.icon.useIcon = true;
       style.icon.iconType = 'back';
@@ -295,7 +300,7 @@ describe('style-formatter', () => {
       const text = button.children[0];
       expect(text.children[0].style.textDecoration).to.equal('none');
       expect(text.children[1].textContent).to.equal('Button');
-      expect(button.children[0].style.fontSize).to.equal('11px');
+      expect(button.children[0].style.fontSize).to.equal('10.5px');
     });
 
     it('should place label first then icon inside text element', () => {

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -93,7 +93,7 @@ describe('style-formatter', () => {
     });
 
     it('should return font-style: italic when italic is selected', () => {
-      style.font.style.italic = {
+      style.font.style = {
         italic: true,
       };
       const formattedStyle = styleFormatter.getStyles({ style, disabled, theme });
@@ -276,7 +276,7 @@ describe('style-formatter', () => {
     });
 
     it('should set fontSize when italic is selected', () => {
-      style.font.style.italic = {
+      style.font.style = {
         italic: true,
       };
       button.appendChild = child => {
@@ -289,8 +289,8 @@ describe('style-formatter', () => {
       expect(button.children[0].style.fontSize).to.equal('9px');
     });
 
-    it('should place icon first then label inside text element', () => {
-      style.font.style.italic = {
+    it('should place icon first then label inside text element with italics', () => {
+      style.font.style = {
         italic: true,
       };
       const isSense = true;

--- a/src/utils/style-formatter.js
+++ b/src/utils/style-formatter.js
@@ -1,4 +1,5 @@
 import colorUtils from './color-utils';
+import luiIcons from './lui-icons';
 
 const backgroundSize = {
   auto: 'auto auto',
@@ -75,26 +76,28 @@ export default {
     return styles;
   },
   createLabelAndIcon({ button, theme, style, isSense }) {
+    const { icon, font, label } = style;
     // text element wrapping label and icon
     const text = document.createElement('text');
     text.style.whiteSpace = 'nowrap';
     text.style.fontFamily = theme.getStyle('', '', 'fontFamily');
     // label
     const textSpan = document.createElement('span');
-    textSpan.textContent = style.label;
+    textSpan.textContent = label;
     textSpan.style.whiteSpace = 'nowrap';
     textSpan.style.textOverflow = 'ellipsis';
     textSpan.style.overflow = 'visible';
-    style.font.style.underline && (textSpan.style.textDecoration = 'underline');
+    font.style.underline && (textSpan.style.textDecoration = 'underline');
     text.appendChild(textSpan);
     // icon
-    const hasIcon = isSense && style.icon.useIcon && style.icon.iconType !== '';
+    const hasIcon = isSense && icon.useIcon && icon.iconType !== '';
     if (hasIcon) {
       const iconSpan = document.createElement('span');
+      const iconType = luiIcons.find(iconObj => iconObj.label === icon.iconType || iconObj.value === icon.iconType);
       iconSpan.style.textDecoration = 'none';
       iconSpan.style.fontSize = 'inherit';
-      iconSpan.setAttribute('class', `lui-icon lui-icon--${style.icon.iconType}`);
-      style.icon.position === 'left' ? text.insertBefore(iconSpan, textSpan) : text.appendChild(iconSpan);
+      iconSpan.setAttribute('class', `lui-icon lui-icon--${iconType ? iconType.value : ''}`);
+      icon.position === 'left' ? text.insertBefore(iconSpan, textSpan) : text.appendChild(iconSpan);
     }
     button.innerHTML = '';
     button.appendChild(text);
@@ -110,20 +113,20 @@ export default {
       newFontsize *= button.clientWidth / text.offsetWidth;
     }
     // 4. Setting final font size by scaling with the font size from the layout + other font styling
-    if (style.font.style.italic) {
+    if (font.style.italic) {
       if (hasIcon) {
-        text.style.fontSize = `${Math.max(newFontsize * style.font.size * 0.84, 8)}px`;
+        text.style.fontSize = `${Math.max(newFontsize * font.size * 0.84, 8)}px`;
         text.children[0].style.marginRight = `${text.offsetWidth * 0.04}px`;
         text.children[1].style.marginRight = `${text.offsetWidth * 0.04}px`;
       } else {
-        text.style.fontSize = `${Math.max(newFontsize * style.font.size * 0.90, 8)}px`;
+        text.style.fontSize = `${Math.max(newFontsize * font.size * 0.9, 8)}px`;
         text.children[0].style.marginRight = `${text.offsetWidth * 0.02}px`;
       }
     } else if (hasIcon) {
-      text.style.fontSize = `${Math.max(newFontsize * style.font.size * 0.88, 8)}px`;
+      text.style.fontSize = `${Math.max(newFontsize * font.size * 0.88, 8)}px`;
       text.children[0].style.marginRight = `${text.offsetWidth * 0.04}px`;
     } else {
-      text.style.fontSize = `${Math.max(newFontsize * style.font.size * 0.92, 8)}px`;
+      text.style.fontSize = `${Math.max(newFontsize * font.size * 0.92, 8)}px`;
     }
     // hide overflow when there can be overflow
     if (text.style.fontSize === '8px') {
@@ -134,7 +137,6 @@ export default {
     text.style.margin = '0 3%';
     text.style.display = 'flex';
     text.style.alignItems = 'center';
-    text.style.justifyContent =
-      style.font.align === 'left' ? 'flex-start' : style.font.align === 'right' ? 'flex-end' : 'center';
+    text.style.justifyContent = font.align === 'left' ? 'flex-start' : font.align === 'right' ? 'flex-end' : 'center';
   },
 };


### PR DESCRIPTION
So making sure we get a correct label from the `expression-with-dropdown` component, both the label and value can be used in an expression now.

Also found that the `layout` was not resetting, so hade do parse it.