### PR TITLE
feat: add option show condition

### DIFF
--- a/src/__tests__/ext.spec.js
+++ b/src/__tests__/ext.spec.js
@@ -84,6 +84,9 @@ describe('ext', () => {
         qInfo: {
           qId: 'firstSheetId',
         },
+        qData: {
+          showCondition: '0',
+        }
       },
       {
         qMeta: {
@@ -92,6 +95,9 @@ describe('ext', () => {
         qInfo: {
           qId: 'secondSheetId',
         },
+        qData: {
+          showCondition: '1',
+        }
       },
     ];
     const stories = [

--- a/src/ext.js
+++ b/src/ext.js
@@ -177,6 +177,7 @@ export default function ext({ translator }) {
                     return sheets.map(sheet => ({
                       value: sheet.qInfo.qId,
                       label: sheet.qMeta.title,
+                      showCondition: sheet.qData.showCondition,
                     }));
                   },
                 },


### PR DESCRIPTION
Part of PS-14085 - sheet show condition

This PR is part of visual changes for hidden sheets on the action button https://jira.qlikdev.com/browse/SUI-6772

Feature flag: SHEET_SHOW_CONDITION

Add show condition to be part of the options of the extension, this will help to evaluate the show condition on the sheet and display the visual icon if the sheet is hidden.

Changes on the client side are covered in this PR:

https://github.com/qlik-trial/sense-client/pull/14422
