### PR TITLE
fix: remove tabindex from actionbutton

### DIFF
--- a/src/components/action-button.js
+++ b/src/components/action-button.js
@@ -17,6 +17,7 @@ export default function renderButton({ layout, theme, app, constraints, senseNav
   const isClickable = !disabled && !constraints.active;
   const formattedStyles = styleFormatter.getStyles({ style, disabled, theme, element });
   button.setAttribute('style', formattedStyles);
+  button.setAttribute('tabindex', '-1');
   styleFormatter.createLabelAndIcon({ button, theme, style, isSense });
 
   button.onclick = async () => {


### PR DESCRIPTION
Previously action-button took focus from grid-cell which it shouldnt. This fixes https://jira.qlikdev.com/browse/QB-7434.

Tested on windows and localhost. 

You can still tab to the gridcell the action-button is in and press enter to perform the action. 