### PR TITLE
docs: add exception for icons

### DIFF
--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -252,7 +252,7 @@
           "type": "#/definitions/ColorExpression"
         },
         "useImage": {
-          "description": "Set to true to show background image. Only available inside Qlik Sense",
+          "description": "Set to true to show background image",
           "optional": true,
           "defaultValue": false,
           "type": "boolean"

--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -252,7 +252,7 @@
           "type": "#/definitions/ColorExpression"
         },
         "useImage": {
-          "description": "Set to true to show background image",
+          "description": "Set to true to show background image. Only available inside Qlik Sense",
           "optional": true,
           "defaultValue": false,
           "type": "boolean"
@@ -502,6 +502,7 @@
       }
     },
     "Icon": {
+      "description": "Icons are only available inside Qlik Sense",
       "kind": "object",
       "entries": {
         "useIcon": {

--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -150,7 +150,7 @@ const properties = {
  * @property {boolean=} [useColorExpression=false] - Set to true to use color expression
  * @property {PaletteColor=} color - Color defined by index or hex code, needed if useColorExpression is false
  * @property {ColorExpression=} colorExpression - Color defined by expression, needed if useColorExpression is true
- * @property {boolean=} [useImage=false] - Set to true to show background image
+ * @property {boolean=} [useImage=false] - Set to true to show background image. Only available inside Qlik Sense
  * @property {object=} url - Contains the URL for the background image
  * @property {object=} url.qStaticContentUrlDef
  * @property {string=} url.qStaticContentUrlDef.qUrl - URL represented as a string
@@ -169,6 +169,7 @@ const properties = {
  */
 
 /**
+ * Icons are only available inside Qlik Sense
  * @typedef {object} Icon
  * @property {boolean=} [useIcon=false] - Set to true to show icon, default is false
  * @property {object=} iconType - holds the name of the icon

--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -150,7 +150,7 @@ const properties = {
  * @property {boolean=} [useColorExpression=false] - Set to true to use color expression
  * @property {PaletteColor=} color - Color defined by index or hex code, needed if useColorExpression is false
  * @property {ColorExpression=} colorExpression - Color defined by expression, needed if useColorExpression is true
- * @property {boolean=} [useImage=false] - Set to true to show background image. Only available inside Qlik Sense
+ * @property {boolean=} [useImage=false] - Set to true to show background image
  * @property {object=} url - Contains the URL for the background image
  * @property {object=} url.qStaticContentUrlDef
  * @property {string=} url.qStaticContentUrlDef.qUrl - URL represented as a string


### PR DESCRIPTION
As I was creating examples I noticed that you can't do icons outside sense