### PR TITLE
fix: button url should work for multinoded windows

### DIFF
--- a/src/utils/url-utils.js
+++ b/src/utils/url-utils.js
@@ -3,7 +3,7 @@ const getImageUrl = (imgUrl) => {
   imgUrl = imgUrl.replace(/"/g, '\\"');
   imgUrl = imgUrl.replace(/'/g, "\\'");
   const a = document.createElement('a');
-  a.href = '/';
+  a.href = '../';
   const rootPath = a.href;
   imgUrl = rootPath + (imgUrl[0] === '/' ? imgUrl.substr(1) : imgUrl);
   return imgUrl;


### PR DESCRIPTION
This is a fix for: https://jira.qlikdev.com/browse/QB-16816
I have tried it by building this button and testing it on the multinoded server alongside a non fixed button. The nonfixed button has no image and this fixed button has an image. 

This fix will revert this fix: https://github.com/qlik-oss/sn-action-button/pull/300

But I think its ok, I think Niek might have solved the url issues in this way instead: https://github.com/qlik-oss/sn-action-button/commit/60468ac0a5e1016e30f1b3a9bdf3806c6cfdcf89 in a later fix.

In either way, this is how we use base path in sense-client.