### PR TITLE
feat: adding sizing options to label (without fluid type)

### DIFF
--- a/src/__tests__/ext.spec.js
+++ b/src/__tests__/ext.spec.js
@@ -6,7 +6,7 @@ describe('ext', () => {
     get: (someString) => someString,
   };
   let data;
-  const shouldHide = jest.fn();
+  const shouldHide = { isEnabled: () => true };
   const senseNavigation = {
     getOdagLinks: () =>
       Promise.resolve([{ properties: { data: { id: 'TestOdagLink', name: 'TestOdagLink' }, type: 'odaglink' } }]),
@@ -339,13 +339,26 @@ describe('ext', () => {
       expect(resultPicker).toBe(false);
     });
 
+    it('should return true for fontSize and false for fontSizeFixed when relative font size', () => {
+      expect(font.items.sizeAndColor.items.fontSize.show(data)).toBe(true);
+      expect(font.items.sizeAndColor.items.fontSizeFixed.show(data)).toBe(false);
+      expect(font.items.sizeAndColor.items.fontSizeBehavior.show(data)).toBe(true);
+    });
+
+    it('should return false for fontSize and true for fontSizeFixed when fixed font size', () => {
+      data.style.font.sizeBehavior = 'fixed';
+      expect(font.items.sizeAndColor.items.fontSize.show(data)).toBe(false);
+      expect(font.items.sizeAndColor.items.fontSizeFixed.show(data)).toBe(true);
+    });
+
+    // background
     it('should return false for expression and true for picker when background.useColorExpression is false', () => {
       const resultExpression = background.items.backgroundColor.items.colorExpression.show(data);
       const resultPicker = background.items.backgroundColor.items.colorPicker.show(data);
       expect(resultExpression).toBe(false);
       expect(resultPicker).toBe(true);
     });
-    // background
+
     it('should return true for expression and false for picker when background.useColorExpression is true', () => {
       data.style.background.useColorExpression = true;
       const resultExpression = background.items.backgroundColor.items.colorExpression.show(data);

--- a/src/ext.js
+++ b/src/ext.js
@@ -26,7 +26,23 @@ const toggleOptions = [
   },
 ];
 
+const fontSizeOptions = [
+  {
+    value: 'responsive',
+    translation: 'properties.responsive',
+  },
+  {
+    value: 'relative',
+    translation: 'properties.fluid',
+  },
+  {
+    value: 'fixed',
+    translation: 'properties.fixed',
+  },
+];
+
 export default function ext({ translator, shouldHide, senseNavigation }) {
+  const { isEnabled } = shouldHide;
   return {
     definition: {
       type: 'items',
@@ -333,6 +349,14 @@ export default function ext({ translator, shouldHide, senseNavigation }) {
                 sizeAndColor: {
                   type: 'items',
                   items: {
+                    fontSizeBehavior: {
+                      component: 'dropdown',
+                      ref: 'style.font.sizeBehavior',
+                      options: fontSizeOptions,
+                      translation: 'properties.kpi.layoutBehavior',
+                      defaultValue: 'responsive',
+                      show: () => isEnabled('IM_324_ACTION_BUTTON_SIZES'),
+                    },
                     fontSize: {
                       component: 'slider',
                       type: 'number',
@@ -341,6 +365,19 @@ export default function ext({ translator, shouldHide, senseNavigation }) {
                       min: 0.2,
                       max: 1,
                       step: 0.01,
+                      show: (data) =>
+                        !isEnabled('IM_324_ACTION_BUTTON_SIZES') ||
+                        !data.style.font.sizeBehavior ||
+                        data.style.font.sizeBehavior !== 'fixed',
+                    },
+                    fontSizeFixed: {
+                      type: 'number',
+                      ref: 'style.font.sizeFixed',
+                      expression: 'optional',
+                      min: 5,
+                      defaultValue: 20,
+                      show: (data) =>
+                        isEnabled('IM_324_ACTION_BUTTON_SIZES') && data.style.font.sizeBehavior === 'fixed',
                     },
                     useFontColorExpression: {
                       ref: 'style.font.useColorExpression',

--- a/src/ext.js
+++ b/src/ext.js
@@ -32,10 +32,6 @@ const fontSizeOptions = [
     translation: 'properties.responsive',
   },
   {
-    value: 'relative',
-    translation: 'properties.fluid',
-  },
-  {
     value: 'fixed',
     translation: 'properties.fixed',
   },

--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -148,7 +148,7 @@ const properties = {
  * @property {boolean=} [style.bold = true] - Bold text
  * @property {boolean=} [style.italic = false] - Italic text
  * @property {boolean=} [style.underline = false] - Underlined text
- * @property {('responsive'|'relative'|'fixed')} [sizeBehavior='responsive'] - Setting to determine how the fontsize of the label is calculated.
+ * @property {('responsive'|'fixed')} [sizeBehavior='responsive'] - Setting to determine how the fontsize of the label is calculated.
  */
 
 /**

--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -65,8 +65,10 @@ const properties = {
       color: DEFAULTS.COLOR,
       colorExpression: '',
       size: DEFAULTS.FONT_SIZE,
+      sizeFixed: DEFAULTS.FONT_SIZE_FIXED,
       style: DEFAULTS.FONT_STYLE,
       align: DEFAULTS.TEXT_ALIGN,
+      sizeBehavior: DEFAULTS.SIZE_BEHAVIOR,
     },
     background: {
       useColorExpression: false,
@@ -140,11 +142,13 @@ const properties = {
  * @property {PaletteColor=} color - Color defined by index or hex code, needed if useColorExpression is false
  * @property {ColorExpression=} colorExpression - Color defined by expression, needed if useColorExpression is true
  * @property {number=} [size=0.5] - Relative[] size of label, must be greater than 0 and 1 fills the entire button
+ * @property {number=} [sizeFixed=20] - Fixed size of the label in pixels. Must be bigger than 5. Only active when sizeBehavior is fixed.
  * @property {('left'|'center'|'right')=} [align='center'] - Horizontal alignment
  * @property {object=} style - Additional style options
  * @property {boolean=} [style.bold = true] - Bold text
  * @property {boolean=} [style.italic = false] - Italic text
  * @property {boolean=} [style.underline = false] - Underlined text
+ * @property {('responsive'|'relative'|'fixed')} [sizeBehavior='responsive'] - Setting to determine how the fontsize of the label is calculated.
  */
 
 /**

--- a/src/style-defaults.js
+++ b/src/style-defaults.js
@@ -1,6 +1,7 @@
 export default {
   LABEL: 'Button',
   FONT_SIZE: 0.5,
+  FONT_SIZE_FIXED: 20,
   COLOR: { index: -1, color: null },
   FONT_STYLE: { bold: true, italic: false, underline: false },
   TEXT_ALIGN: 'center',
@@ -9,4 +10,5 @@ export default {
   BORDER_RADIUS: 0,
   BORDER_WIDTH: 0,
   ICON_POSITION: 'left',
+  SIZE_BEHAVIOR: 'responsive',
 };

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -238,7 +238,7 @@ describe('style-formatter', () => {
       styleFormatter.createLabelAndIcon({ theme, button, style });
       const text = button.children[0];
       expect(text.children[0].textContent).toEqual('Button');
-      expect(text.style.whiteSpace).toEqual('nowrap');
+      expect(text.style.whiteSpace).toEqual('pre');
       expect(text.style.fontFamily).toEqual('myFont');
       expect(text.style.fontSize).toEqual('11.5px');
       expect(text.style.display).toEqual('flex');

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -205,6 +205,9 @@ describe('style-formatter', () => {
           firstElementChild: { setAttribute: () => {} },
           style: {},
           children: [],
+          getContext: () => ({
+            measureText: () => ({ width: 8 }),
+          }),
         };
         newElement.appendChild = (newChild) => {
           newElement.children.push(newChild);
@@ -266,6 +269,45 @@ describe('style-formatter', () => {
       };
       styleFormatter.createLabelAndIcon({ theme, button, style });
       expect(button.children[0].style.fontSize).toEqual('9.200000000000001px');
+    });
+
+    it('should use default fixed font size when size behavior is fixed', () => {
+      button.appendChild = (child) => {
+        child.setAttribute = jest.fn();
+        child.offsetHeight = 400;
+        child.offsetWidth = 400;
+        button.children.push(child);
+      };
+      style.font.sizeBehavior = 'fixed';
+      styleFormatter.createLabelAndIcon({ theme, button, style });
+      expect(button.children[0].style.fontSize).toEqual('20px');
+    });
+
+    it('should use fixed font size when size behavior is fixed', () => {
+      button.appendChild = (child) => {
+        child.setAttribute = jest.fn();
+        child.offsetHeight = 400;
+        child.offsetWidth = 400;
+        button.children.push(child);
+      };
+      style.font.sizeBehavior = 'fixed';
+      style.font.sizeFixed = 16;
+      styleFormatter.createLabelAndIcon({ theme, button, style });
+      expect(button.children[0].style.fontSize).toEqual('16px');
+    });
+
+    it('should calculate correct font size when behavior is relative', () => {
+      button.appendChild = (child) => {
+        child.setAttribute = jest.fn();
+        child.offsetHeight = 400;
+        child.offsetWidth = 400;
+        button.children.push(child);
+      };
+      style.font.sizeBehavior = 'relative';
+      style.label =
+        'a very very very very very very very very very very very very very very very very very very very very long title';
+      styleFormatter.createLabelAndIcon({ theme, button, style });
+      expect(button.children[0].style.fontSize).toEqual('12.5px');
     });
 
     it('should set fontSize when italic is selected', () => {

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -287,7 +287,7 @@ describe('style-formatter', () => {
       expect(button.children[0].style.fontSize).toEqual('20px');
     });
 
-    it('should use fixed font size when size behavior is fixed', () => {
+    it('should use specified fixed font size when size behavior is fixed', () => {
       button.appendChild = (child) => {
         child.setAttribute = jest.fn();
         child.offsetHeight = 400;

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -212,9 +212,6 @@ describe('style-formatter', () => {
           firstElementChild: { setAttribute: () => {} },
           style: {},
           children: [],
-          getContext: () => ({
-            measureText: () => ({ width: 8 }),
-          }),
         };
         newElement.appendChild = (newChild) => {
           newElement.children.push(newChild);

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -296,20 +296,6 @@ describe('style-formatter', () => {
       expect(button.children[0].style.fontSize).toEqual('16px');
     });
 
-    it('should calculate correct font size when behavior is relative', () => {
-      button.appendChild = (child) => {
-        child.setAttribute = jest.fn();
-        child.offsetHeight = 400;
-        child.offsetWidth = 400;
-        button.children.push(child);
-      };
-      style.font.sizeBehavior = 'relative';
-      style.label =
-        'a very very very very very very very very very very very very very very very very very very very very long title';
-      styleFormatter.createLabelAndIcon({ theme, button, style });
-      expect(button.children[0].style.fontSize).toEqual('12.5px');
-    });
-
     it('should set fontSize when italic is selected', () => {
       style.font.style = {
         italic: true,

--- a/src/utils/style-formatter.js
+++ b/src/utils/style-formatter.js
@@ -115,8 +115,12 @@ export default {
     button.appendChild(text);
 
     if (font.sizeBehavior === 'fixed') {
-      text.style.fontSize = `${font.sizeFixed || DEFAULTS.FONT_SIZE_FIXED}px`;
+      const fontSize = font.sizeFixed || DEFAULTS.FONT_SIZE_FIXED;
+      text.style.fontSize = `${fontSize}px`;
       textSpan.style.overflow = 'hidden';
+      if (hasIcon) {
+        text.children[0].style.marginRight = `${fontSize * 0.3}px`;
+      }
     } else {
       // Calculations on font size.
       // 1. Setting font size to height of button container

--- a/src/utils/style-formatter.js
+++ b/src/utils/style-formatter.js
@@ -114,13 +114,7 @@ export default {
     button.innerHTML = '';
     button.appendChild(text);
 
-    if (font.sizeBehavior === 'relative') {
-      // 40 here is just a hard coded value which seems to work quite well.
-      const calculatedWidth = 40 / font.size;
-      const fontSize = Math.min((button.clientWidth / calculatedWidth) * 10, button.clientHeight * font.size * 0.8);
-      text.style.fontSize = `${fontSize}px`;
-      textSpan.style.overflow = 'hidden';
-    } else if (font.sizeBehavior === 'fixed') {
+    if (font.sizeBehavior === 'fixed') {
       text.style.fontSize = `${font.sizeFixed || DEFAULTS.FONT_SIZE_FIXED}px`;
       textSpan.style.overflow = 'hidden';
     } else {

--- a/src/utils/style-formatter.js
+++ b/src/utils/style-formatter.js
@@ -42,14 +42,6 @@ const getColor = (
   return !resolvedColor || resolvedColor === 'none' ? defaultColor : resolvedColor;
 };
 
-export function measureText(text, font) {
-  const canvas = measureText.canvas || (measureText.canvas = document.createElement('canvas'));
-  const context = canvas.getContext('2d');
-  context.font = font;
-  const metrics = context.measureText(text);
-  return metrics;
-}
-
 export default {
   getStyles({ style = {}, disabled, theme, element }) {
     let styles =
@@ -123,13 +115,14 @@ export default {
     button.appendChild(text);
 
     if (font.sizeBehavior === 'relative') {
-      const calculatedWidth =
-        (8 / font.size) *
-        measureText('M', `10px ${theme.getStyle('object.button', 'label.value', 'fontFamily')}`).width;
+      // 40 here is just a hard coded value which seems to work quite well.
+      const calculatedWidth = 40 / font.size;
       const fontSize = Math.min((button.clientWidth / calculatedWidth) * 10, button.clientHeight * font.size * 0.8);
       text.style.fontSize = `${fontSize}px`;
+      textSpan.style.overflow = 'hidden';
     } else if (font.sizeBehavior === 'fixed') {
       text.style.fontSize = `${font.sizeFixed || DEFAULTS.FONT_SIZE_FIXED}px`;
+      textSpan.style.overflow = 'hidden';
     } else {
       // Calculations on font size.
       // 1. Setting font size to height of button container


### PR DESCRIPTION
This PR is based on Niek's work in here: https://github.com/qlik-oss/sn-action-button/pull/312 

but with a little difference in order to fix the required criteria's that has been asked and make it's way to the production level. 
 
So what is different in this pr is the ability to choose "Fluid" option. because we decided at the moment to skip it for now since it is already fulfilling the requested demand on font size option. 

with a lot of thanks to @niekvanstaveren on his work and effort on making this possible, I would say that this PR is ready to get merged. 
