### PR TITLE
feat: enable Chart styling panel for label styling

### DIFF
--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -451,6 +451,12 @@
           "optional": true,
           "type": "#/definitions/ColorExpression"
         },
+        "fontFamily": {
+          "description": "Font family of the label",
+          "optional": true,
+          "defaultValue": "Source Sans Pro",
+          "type": "string"
+        },
         "size": {
           "description": "Relative[] size of label, must be greater than 0 and 1 fills the entire button",
           "optional": true,

--- a/src/ext.js
+++ b/src/ext.js
@@ -1,9 +1,10 @@
 import actions, { checkShowAction, getActionsList } from './utils/actions';
 import { checkShowNavigation, getNavigationsList } from './utils/navigation-actions';
+import { getStylingPanelDefinition } from './styling-panel-definition';
 import propertyResolver from './utils/property-resolver';
 import importProperties from './utils/conversion';
 import luiIcons from './utils/lui-icons';
-import getStylingPanelDefinition from './styling-panel-definition';
+import { colorOptions, toggleOptions } from './utils/style-utils';
 import getAutomationProps from './utils/automation-props';
 
 let automationsList = null;
@@ -19,29 +20,6 @@ const getAutomations = async () => {
   }
   return automationsList;
 };
-
-const colorOptions = [
-  {
-    value: false,
-    translation: 'properties.colorMode.primary',
-  },
-  {
-    value: true,
-    translation: 'properties.colorMode.byExpression',
-  },
-];
-
-const toggleOptions = [
-  {
-    value: true,
-    translation: 'properties.on',
-  },
-  {
-    value: false,
-    translation: 'properties.off',
-  },
-];
-
 export default function ext({ translator, shouldHide, senseNavigation }) {
   const multiUserAutomation =
     shouldHide.isEnabled && shouldHide.isEnabled('SENSECLIENT_IM_1855_AUTOMATIONS_MULTI_USER');
@@ -434,6 +412,7 @@ export default function ext({ translator, shouldHide, senseNavigation }) {
                   },
                 },
               },
+              show: !stylingPanelEnabled,
             },
             background: {
               grouped: true,

--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -63,6 +63,7 @@ const properties = {
   style: {
     label: DEFAULTS.LABEL,
     font: {
+      fontFamily: DEFAULTS.FONT_FAMILY,
       useColorExpression: false,
       color: DEFAULTS.COLOR,
       colorExpression: '',
@@ -151,6 +152,7 @@ const properties = {
 
 /**
  * @typedef {object} Font
+ * @property {string=} [fontFamily='Source Sans Pro'] - Font Family of the label
  * @property {boolean=} [useColorExpression=false] - Set to true to use color expression
  * @property {PaletteColor=} color - Color defined by index or hex code, needed if useColorExpression is false
  * @property {ColorExpression=} colorExpression - Color defined by expression, needed if useColorExpression is true

--- a/src/style-defaults.js
+++ b/src/style-defaults.js
@@ -3,6 +3,7 @@ export default {
   FONT_SIZE: 0.5,
   COLOR: { index: -1, color: null },
   FONT_STYLE: { bold: true, italic: false, underline: false },
+  FONT_FAMILY: 'Source Sans Pro',
   TEXT_ALIGN: 'center',
   BACKGROUND_SIZE: 'auto',
   BACKGROUND_POSITION: 'centerCenter',

--- a/src/styling-panel-definition.js
+++ b/src/styling-panel-definition.js
@@ -1,4 +1,86 @@
-const getStylingPanelDefinition = (bkgOptionsEnabled) => ({
+import styleDefaults from './style-defaults';
+import propertyResolver from './utils/property-resolver';
+import { fontFamilyOptions, colorOptions } from './utils/style-utils';
+
+export const getStyleEditorDefinition = () => ({
+  items: {
+    labelSection: {
+      component: 'panel-section',
+      translation: 'Common.Label',
+      items: {
+        labelItem: {
+          items: {
+            fontFamily: {
+              component: 'dropdown',
+              ref: 'style.font.fontFamily',
+              options: fontFamilyOptions,
+              defaultValue: styleDefaults.FONT_FAMILY,
+            },
+            fontWrapper: {
+              component: 'inline-wrapper',
+              type: 'items',
+              grouped: true,
+              items: {
+                fontStyle: {
+                  type: 'array',
+                  component: 'font-style-buttons',
+                  width: false,
+                  ref: 'style.font.style',
+                  defaultValue: ['bold'],
+                },
+                textAlign: {
+                  component: 'text-align-buttons',
+                  ref: 'style.font.align',
+                  defaultValue: styleDefaults.TEXT_ALIGN,
+                },
+              },
+            },
+            fontSize: {
+              component: 'slider',
+              type: 'number',
+              ref: 'style.font.size',
+              translation: 'properties.fontSize',
+              min: 0.2,
+              max: 1,
+              step: 0.01,
+              defaultValue: 0.5,
+            },
+            fontColor: {
+              items: {
+                useFontColorExpression: {
+                  ref: 'style.font.useColorExpression',
+                  type: 'boolean',
+                  translation: 'properties.fontColor',
+                  component: 'dropdown',
+                  width: 14,
+                  options: colorOptions,
+                },
+                colorPicker: {
+                  component: 'color-picker',
+                  type: 'object',
+                  ref: 'style.font.color',
+                  translation: 'properties.color',
+                  width: 12,
+                  show: (data) => !propertyResolver.getValue(data, 'style.font.useColorExpression'),
+                },
+                colorExpression: {
+                  type: 'string',
+                  component: 'input-field-expression',
+                  ref: 'style.font.colorExpression',
+                  translation: 'Common.Expression',
+                  expression: 'optional',
+                  show: (data) => propertyResolver.getValue(data, 'style.font.useColorExpression'),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+export const getStylingPanelDefinition = (bkgOptionsEnabled) => ({
   type: 'items',
   grouped: false,
   translation: 'properties.presentation',
@@ -11,7 +93,7 @@ const getStylingPanelDefinition = (bkgOptionsEnabled) => ({
       ref: 'components',
       useGeneral: true,
       useBackground: bkgOptionsEnabled,
+      ...getStyleEditorDefinition(),
     },
   },
 });
-export default getStylingPanelDefinition;

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -241,12 +241,11 @@ describe('style-formatter', () => {
     });
 
     it('should set fontSize and styling', () => {
-      theme.getStyle = jest.fn(() => 'myFont');
       styleFormatter.createLabelAndIcon({ theme, button, style });
       const text = button.children[0];
       expect(text.children[0].textContent).toEqual('Button');
       expect(text.style.whiteSpace).toEqual('nowrap');
-      expect(text.style.fontFamily).toEqual('myFont');
+      expect(text.style.fontFamily).toEqual('Source Sans Pro');
       expect(text.style.fontSize).toEqual('11.5px');
       expect(text.style.display).toEqual('flex');
       expect(text.style.alignItems).toEqual('center');

--- a/src/utils/style-formatter.js
+++ b/src/utils/style-formatter.js
@@ -50,13 +50,13 @@ export default {
     const primaryColor = theme.getDataColorSpecials().primary;
     // enable
     styles += disabled ? formatProperty('opacity', 0.4) : formatProperty('cursor', 'pointer');
+    const backgroundColor = getColor(background, primaryColor, theme);
     // font
     styles += formatProperty('color', getColor(font, '#ffffff', theme));
     const fontStyle = font.style || DEFAULTS.FONT_STYLE;
     fontStyle.bold && (styles += formatProperty('font-weight', 'bold'));
     fontStyle.italic && (styles += formatProperty('font-style', 'italic'));
     // background
-    const backgroundColor = getColor(background, primaryColor, theme);
     styles += formatProperty('background-color', backgroundColor);
     if (background.useImage && background.url.qStaticContentUrl) {
       let bgUrl = background.url.qStaticContentUrl.qUrl;
@@ -92,7 +92,8 @@ export default {
     // text element wrapping label and icon
     const text = document.createElement('text');
     text.style.whiteSpace = 'nowrap';
-    text.style.fontFamily = theme.getStyle('', '', 'fontFamily');
+    text.style.fontFamily = style.font.fontFamily || theme.getStyle('', '', 'fontFamily') || DEFAULTS.FONT_FAMILY;
+
     // label
     const textSpan = document.createElement('span');
     textSpan.textContent = label;

--- a/src/utils/style-utils.js
+++ b/src/utils/style-utils.js
@@ -1,0 +1,50 @@
+const FONT_FAMILIES = [
+  'American Typewriter, serif',
+  'Andalé Mono, monospace',
+  'Arial Black, sans-serif',
+  'Arial, sans-serif',
+  'Bradley Hand, cursive',
+  'Brush Script MT, cursive',
+  'Comic Sans MS, cursive',
+  'Courier, monospace',
+  'Didot, serif',
+  'Georgia, serif',
+  'Impact, sans-serif',
+  'Lucida Console, monospace',
+  'Luminari, fantasy',
+  'Monaco, monospace',
+  'QlikView Sans, sans-serif',
+  'Source Sans Pro, sans-serif',
+  'Tahoma, sans-serif',
+  'Times New Roman, serif',
+  'Trebuchet MS, sans-serif',
+  'Verdana, sans-serif',
+];
+
+export const colorOptions = [
+  {
+    value: false,
+    translation: 'properties.colorMode.primary',
+  },
+  {
+    value: true,
+    translation: 'properties.colorMode.byExpression',
+  },
+];
+
+export const toggleOptions = [
+  {
+    value: true,
+    translation: 'properties.on',
+  },
+  {
+    value: false,
+    translation: 'properties.off',
+  },
+];
+
+const getFirstFont = (s) => s.split(',')[0];
+export const fontFamilyOptions = FONT_FAMILIES.map((font) => ({
+  value: font,
+  label: getFirstFont(font),
+}));


### PR DESCRIPTION
**In this PR:** 
Enable styling panel chart tab which includes the listed items: (the backward compatibility has also been considered)
- Enabling Chart tab
- FontFamily dropdown
- Font style
- Text align
- FontSize
- FontColor (single and expression)
- Reset the Label section option

**Feature-flag:** SENSECLIENT_IM_1525_STYLINGPANEL_BUTTON
**Note:** To be able to test it locally, sense-client needs to be linked to analytic changes on my branch [here](https://github.com/qlik-trial/analytics/pull/401) and for getting new translations to [sense-client](https://github.com/qlik-trial/sense-client/pull/23139)

**Unsolved Issues:**

- The font size tooltip looks like moving behind the font styling wrapper in its current location. If we consider LayoutBehavior component which is supposed to be set between these two, it will not behave the same so it might not be the matter of issue for now. LayoutBehavior will be added in a separate PR.

- ResetAll which resets all the components on the panel at the same time, doesn't work. This function works with component key that has not been considered in this feature. I'll consider it in another PR.

https://user-images.githubusercontent.com/20701546/217811775-404c71a3-0d92-498c-ac49-0faf6d4d831f.mp4
