### PR TITLE
feat: add background options and borders to styling panel

### DIFF
--- a/src/ext.js
+++ b/src/ext.js
@@ -6,6 +6,7 @@ import importProperties from './utils/conversion';
 import luiIcons from './utils/lui-icons';
 import { colorOptions, toggleOptions } from './utils/style-utils';
 import getAutomationProps from './utils/automation-props';
+import styleDefaults from './style-defaults';
 
 let automationsList = null;
 
@@ -474,6 +475,7 @@ export default function ext({ translator, shouldHide, senseNavigation }) {
                       translation: 'properties.backgroundImage.size',
                       type: 'string',
                       component: 'dropdown',
+                      defaultValue: styleDefaults.BACKGROUND_SIZE,
                       options: [
                         {
                           value: 'auto',
@@ -526,6 +528,7 @@ export default function ext({ translator, shouldHide, senseNavigation }) {
                   },
                 },
               },
+              show: !stylingPanelEnabled,
             },
             border: {
               type: 'items',
@@ -593,6 +596,7 @@ export default function ext({ translator, shouldHide, senseNavigation }) {
                   },
                 },
               },
+              show: !stylingPanelEnabled,
             },
             icon: {
               type: 'items',

--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -65,7 +65,7 @@ const properties = {
     font: {
       fontFamily: DEFAULTS.FONT_FAMILY,
       useColorExpression: false,
-      color: DEFAULTS.COLOR,
+      color: DEFAULTS.FONT_COLOR,
       colorExpression: '',
       size: DEFAULTS.FONT_SIZE,
       style: DEFAULTS.FONT_STYLE,
@@ -75,6 +75,7 @@ const properties = {
       useColorExpression: false,
       color: DEFAULTS.COLOR,
       colorExpression: '',
+      mode: DEFAULTS.BGIMAGE_MODE,
       useImage: false,
       url: {
         qStaticContentUrlDef: {
@@ -169,11 +170,12 @@ const properties = {
  * @property {boolean=} [useColorExpression=false] - Set to true to use color expression
  * @property {PaletteColor=} color - Color defined by index or hex code, needed if useColorExpression is false
  * @property {ColorExpression=} colorExpression - Color defined by expression, needed if useColorExpression is true
+ * @property {('none'|'media')=} [mode = 'none'] - Toggles the background image, set to media to show the image
  * @property {boolean=} [useImage=false] - Set to true to show background image
  * @property {object=} url - Contains the URL for the background image
  * @property {object=} url.qStaticContentUrlDef
  * @property {string=} url.qStaticContentUrlDef.qUrl - URL represented as a string
- * @property {('topLeft'|'centerLeft'|'bottomLeft'|'topCenter'|'centerCenter'|'bottomCenter'|'topRight'|'centerRight'|'bottomRight')} [position='centerCenter'] - Image position
+ * @property {('topLeft'|'centerLeft'|'bottomLeft'|'topCenter'|'centerCenter'|'bottomCenter'|'topRight'|'centerRight'|'bottomRight'|'top-left'|'center-left'|'bottom-left'|'top-center'|'center-center'|'top-right'|'center-right'|'bottom-right')} [position='center-center'] - Image position
  * @property {('auto'|'alwaysFit'|'fitWidth'|'fitWidth'|'fitHeight'|'fill'|'alwaysFill')=} [size='auto'] - Size of the image, relative to the button
  */
 

--- a/src/style-defaults.js
+++ b/src/style-defaults.js
@@ -1,13 +1,16 @@
 export default {
   LABEL: 'Button',
   FONT_SIZE: 0.5,
-  COLOR: { index: -1, color: null },
+  FONT_COLOR: { index: -1, color: '#ffffff' },
   FONT_STYLE: { bold: true, italic: false, underline: false },
   FONT_FAMILY: 'Source Sans Pro',
   TEXT_ALIGN: 'center',
+  COLOR: { index: -1, color: 'none' },
+  ICON_POSITION: 'left',
+  BGIMAGE_MODE: 'none',
+  BGIMAGE_POSITION: 'center-center',
   BACKGROUND_SIZE: 'auto',
   BACKGROUND_POSITION: 'centerCenter',
   BORDER_RADIUS: 0,
   BORDER_WIDTH: 0,
-  ICON_POSITION: 'left',
 };

--- a/src/styling-panel-definition.js
+++ b/src/styling-panel-definition.js
@@ -1,6 +1,6 @@
 import styleDefaults from './style-defaults';
 import propertyResolver from './utils/property-resolver';
-import { fontFamilyOptions, colorOptions } from './utils/style-utils';
+import { fontFamilyOptions, colorOptions, toggleOptions } from './utils/style-utils';
 
 export const getStyleEditorDefinition = () => ({
   items: {
@@ -56,10 +56,12 @@ export const getStyleEditorDefinition = () => ({
                   options: colorOptions,
                 },
                 colorPicker: {
-                  component: 'color-picker',
                   type: 'object',
+                  component: 'color-picker',
                   ref: 'style.font.color',
                   translation: 'properties.color',
+                  defaultValue: styleDefaults.FONT_COLOR,
+                  disabledNone: true,
                   width: 12,
                   show: (data) => !propertyResolver.getValue(data, 'style.font.useColorExpression'),
                 },
@@ -72,6 +74,191 @@ export const getStyleEditorDefinition = () => ({
                   show: (data) => propertyResolver.getValue(data, 'style.font.useColorExpression'),
                 },
               },
+            },
+          },
+        },
+      },
+    },
+    backgroundOptions: {
+      component: 'panel-section',
+      translation: 'properties.background.options',
+      items: {
+        backgroundColor: {
+          type: 'items',
+          items: {
+            useColorExpression: {
+              type: 'boolean',
+              component: 'dropdown',
+              ref: 'style.background.useColorExpression',
+              translation: 'properties.color',
+              options: colorOptions,
+            },
+            colorExpression: {
+              type: 'string',
+              component: 'input-field-expression',
+              ref: 'style.background.colorExpression',
+              translation: 'Common.Expression',
+              expression: 'optional',
+              show: (data) => propertyResolver.getValue(data, 'style.background.useColorExpression'),
+            },
+            colorPicker: {
+              type: 'object',
+              component: 'color-picker',
+              ref: 'style.background.color',
+              translation: 'properties.color.used',
+              disableNone: false,
+              defaultValue: styleDefaults.COLOR,
+              dualOutput: true,
+              show: (data) => !propertyResolver.getValue(data, 'style.background.useColorExpression'),
+            },
+          },
+        },
+        backgroundImage: {
+          items: {
+            backgroundImageMode: {
+              component: 'dropdown',
+              ref: 'style.background.mode',
+              translation: 'properties.backgroundImage',
+              defaultValue: styleDefaults.BGIMAGE_MODE,
+              options: [
+                {
+                  value: 'none',
+                  translation: 'Background.None',
+                },
+                {
+                  value: 'media',
+                  translation: 'MediaLibrary.Header',
+                },
+              ],
+              change(data) {
+                const bgImageComp = data.style.background;
+                bgImageComp
+                  ? (bgImageComp.url = { qStaticContentUrlDef: '' })
+                  : (data.style.background = { url: { qStaticContentUrlDef: '' } });
+              },
+            },
+            MediaLibrary: {
+              component: 'media-library-button',
+              ref: 'style.background.url',
+              translation: 'MediaLibrary.Header',
+              show: (data) => propertyResolver.getValue(data, 'style.background.mode') === 'media',
+            },
+            imageSize: {
+              component: 'dropdown',
+              ref: 'style.background.size',
+              defaultValue: styleDefaults.BACKGROUND_SIZE,
+              options: [
+                {
+                  value: 'auto',
+                  translation: 'properties.backgroundImage.originalSize',
+                },
+                {
+                  value: 'alwaysFit',
+                  translation: 'properties.backgroundImage.sizeAlwaysFit',
+                },
+                {
+                  value: 'fitWidth',
+                  translation: 'properties.backgroundImage.sizeFitWidth',
+                },
+                {
+                  value: 'fitHeight',
+                  translation: 'properties.backgroundImage.sizeFitHeight',
+                },
+                {
+                  value: 'stretchFit',
+                  translation: 'properties.backgroundImage.sizeStretch',
+                },
+                {
+                  value: 'alwaysFill',
+                  translation: 'properties.backgroundImage.sizeAlwaysFill',
+                },
+              ],
+              change: (data) => {
+                let currentPosition = propertyResolver.getValue(data, 'style.background.position');
+                if (currentPosition) currentPosition = styleDefaults.BGIMAGE_POSITION;
+              },
+              show: (data) =>
+                propertyResolver.getValue(data, 'style.background.mode') === 'media' &&
+                !!propertyResolver.getValue(data, 'style.background.url.qStaticContentUrlDef.qUrl'),
+            },
+            position: {
+              component: 'position-grid',
+              ref: 'style.background.position',
+              translation: 'properties.backgroundImage.position',
+              defaultValue: styleDefaults.BGIMAGE_POSITION,
+              show: (data) =>
+                propertyResolver.getValue(data, 'style.background.mode') === 'media' &&
+                propertyResolver.getValue(data, 'style.background.url.qStaticContentUrlDef.qUrl') &&
+                propertyResolver.getValue(data, 'style.background.size') !== 'stretchFit',
+              currentSizeRef: 'style.background.size',
+            },
+          },
+        },
+      },
+    },
+    backgroundBorder: {
+      component: 'panel-section',
+      translation: 'properties.border',
+      items: {
+        backgroundBorderItem: {
+          items: {
+            useBorder: {
+              type: 'boolean',
+              component: 'switch',
+              ref: 'style.border.useBorder',
+              translation: 'properties.border.use',
+              defaultValue: false,
+              options: toggleOptions,
+            },
+            borderRadius: {
+              type: 'number',
+              component: 'slider',
+              ref: 'style.border.radius',
+              translation: 'properties.border.radius',
+              min: 0,
+              max: 1,
+              step: 0.01,
+              show: (data) => propertyResolver.getValue(data, 'style.border.useBorder'),
+            },
+            borderWidth: {
+              type: 'number',
+              component: 'slider',
+              ref: 'style.border.width',
+              translation: 'properties.border.width',
+              min: 0,
+              max: 0.5,
+              step: 0.005,
+              show: (data) => propertyResolver.getValue(data, 'style.border.useBorder'),
+            },
+            colorDropdown: {
+              type: 'string',
+              component: 'dropdown',
+              ref: 'style.border.useColorExpression',
+              translation: 'properties.border.color',
+              options: colorOptions,
+              show: (data) => propertyResolver.getValue(data, 'style.border.useBorder'),
+            },
+            colorPicker: {
+              type: 'object',
+              component: 'color-picker',
+              ref: 'style.border.color',
+              translation: 'properties.color',
+              defaultValue: styleDefaults.COLOR,
+              disableNone: false,
+              dualOutput: true,
+              show: (data) =>
+                propertyResolver.getValue(data, 'style.border.useBorder') &&
+                !propertyResolver.getValue(data, 'style.border.useColorExpression'),
+            },
+            colorExpression: {
+              type: 'string',
+              component: 'input-field-expression',
+              ref: 'style.border.colorExpression',
+              translation: 'Common.Expression',
+              show: (data) =>
+                propertyResolver.getValue(data, 'style.border.useBorder') &&
+                propertyResolver.getValue(data, 'style.border.useColorExpression'),
+              expression: 'optional',
             },
           },
         },

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -98,6 +98,37 @@ describe('style-formatter', () => {
       expect(formattedStyle.includes('background-color: myPrimaryColor')).toBe(true);
     });
 
+    it('should not return specified image url when the background mode is set on none', () => {
+      style.background.useImage = false;
+      style.background.mode = 'none';
+      const formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes('background-size: auto auto')).toBe(false);
+      expect(formattedStyle.includes('background-position: 50% 50%')).toBe(false);
+      expect(formattedStyle.includes('background-repeat: no-repeat')).toBe(false);
+    });
+
+    it('should return specified image url when the background mode is set on media', () => {
+      style.background.useImage = false;
+      style.background.mode = 'media';
+      style.background.url.qStaticContentUrl = { qUrl: someUrl };
+      const formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes(`background-image: url('https://localhost${someUrl}')`)).toBe(true);
+      expect(formattedStyle.includes('background-size: auto auto')).toBe(true);
+      expect(formattedStyle.includes('background-position: 50% 50%')).toBe(true);
+      expect(formattedStyle.includes('background-repeat: no-repeat')).toBe(true);
+    });
+
+    it('should not show size/position when background mode is set on media but the url is not set', () => {
+      style.background.useImage = false;
+      style.background.mode = 'media';
+      style.background.url.qStaticContentUrl = {};
+      const formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes('background-image:')).toBe(false);
+      expect(formattedStyle.includes('background-size:')).toBe(false);
+      expect(formattedStyle.includes('background-position:')).toBe(false);
+      expect(formattedStyle.includes('background-repeat:')).toBe(false);
+    });
+
     it('should return specified image url and default image settings', () => {
       style.background.useImage = true;
       style.background.url.qStaticContentUrl = { qUrl: someUrl };
@@ -116,6 +147,38 @@ describe('style-formatter', () => {
       expect(formattedStyle.includes('background-size:')).toBe(false);
       expect(formattedStyle.includes('background-position:')).toBe(false);
       expect(formattedStyle.includes('background-repeat:')).toBe(false);
+    });
+
+    it('should return specified image size when mode is set to media', () => {
+      expect(style.background.mode).toEqual('none');
+      let formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes('background-size: 100% 100%')).toBe(false);
+      style.background = {
+        mode: 'media',
+        size: 'fill',
+        url: {
+          qStaticContentUrl: {
+            qUrl: someUrl,
+          },
+        },
+      };
+      formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes('background-size: 100% 100%')).toBe(true);
+    });
+
+    it('should return specified image position when mode is set to media', () => {
+      style.background = {
+        mode: 'media',
+        position: 'top-left',
+        size: 'fill',
+        url: {
+          qStaticContentUrl: {
+            qUrl: someUrl,
+          },
+        },
+      };
+      const formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes('background-position: top left')).toBe(true);
     });
 
     it('should return specified image size', () => {

--- a/src/utils/color-utils.js
+++ b/src/utils/color-utils.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-cond-assign */
 import CSSColors from './css-colors';
+import DEFAULTS from '../style-defaults';
 
 const colorUtils = {
   resolveExpression: (input) => {
@@ -56,6 +57,17 @@ const colorUtils = {
     )
       .toString(16)
       .slice(1)}`;
+  },
+  getColor({ useColorExpression = false, colorExpression = '', color = DEFAULTS.COLOR }, defaultColor, theme) {
+    let resolvedColor;
+    if (useColorExpression) {
+      resolvedColor = colorUtils.resolveExpression(colorExpression);
+    } else if (typeof color === 'string') {
+      resolvedColor = color;
+    } else if (color) {
+      resolvedColor = theme.getColorPickerColor(color);
+    }
+    return !resolvedColor || resolvedColor === 'none' ? defaultColor : resolvedColor;
   },
 };
 

--- a/src/utils/style-formatter.js
+++ b/src/utils/style-formatter.js
@@ -2,63 +2,28 @@ import colorUtils from './color-utils';
 import luiIcons from './lui-icons';
 import { getImageUrl } from './url-utils';
 import DEFAULTS from '../style-defaults';
-
-const backgroundSize = {
-  auto: 'auto auto',
-  alwaysFit: 'contain',
-  fitWidth: '100% auto',
-  fitHeight: 'auto 100%',
-  fill: '100% 100%',
-  alwaysFill: 'cover',
-};
-
-const backgroundPosition = {
-  topLeft: '0% 0%', // top left
-  centerLeft: '50% 0%', // center left
-  bottomLeft: '100% 0%', // bottom left
-  topCenter: '0% 50%', // top center
-  centerCenter: '50% 50%', // center center
-  bottomCenter: '100% 50%', // bottom center
-  topRight: '0% 100%', // top right
-  centerRight: '50% 100%', // center right
-  bottomRight: '100% 100%', // bottom right
-};
+import { backgroundSize, backgroundPosition } from './style-utils';
 
 const formatProperty = (path, setting) => `${path}: ${setting};`;
-
-const getColor = (
-  { useColorExpression = false, colorExpression = '', color = DEFAULTS.COLOR },
-  defaultColor,
-  theme
-) => {
-  let resolvedColor;
-  if (useColorExpression) {
-    resolvedColor = colorUtils.resolveExpression(colorExpression);
-  } else if (typeof color === 'string') {
-    resolvedColor = color;
-  } else if (color) {
-    resolvedColor = theme.getColorPickerColor(color);
-  }
-  return !resolvedColor || resolvedColor === 'none' ? defaultColor : resolvedColor;
-};
 
 export default {
   getStyles({ style = {}, disabled, theme, element, app }) {
     let styles =
       'width: 100%;height: 100%;transition: transform .1s ease-in-out;position: absolute;bottom: 0;left: 0; top: 0;right: 0;margin: auto;';
     const { font = {}, background = {}, border = {} } = style;
-    const primaryColor = theme.getDataColorSpecials().primary;
     // enable
     styles += disabled ? formatProperty('opacity', 0.4) : formatProperty('cursor', 'pointer');
-    const backgroundColor = getColor(background, primaryColor, theme);
     // font
-    styles += formatProperty('color', getColor(font, '#ffffff', theme));
+    styles += formatProperty('color', colorUtils.getColor(font, DEFAULTS.FONT_COLOR.color, theme));
     const fontStyle = font.style || DEFAULTS.FONT_STYLE;
     fontStyle.bold && (styles += formatProperty('font-weight', 'bold'));
     fontStyle.italic && (styles += formatProperty('font-style', 'italic'));
     // background
+    const primaryColor = theme.getDataColorSpecials().primary;
+    const backgroundColor = colorUtils.getColor(background, primaryColor, theme);
     styles += formatProperty('background-color', backgroundColor);
-    if (background.useImage && background.url.qStaticContentUrl) {
+    // backgroundImage
+    if ((background.useImage || background.mode === 'media') && background.url.qStaticContentUrl) {
       let bgUrl = background.url.qStaticContentUrl.qUrl;
       if (bgUrl) {
         bgUrl = getImageUrl(bgUrl, app);
@@ -74,7 +39,7 @@ export default {
     // border
     if (border.useBorder) {
       const lengthShortSide = Math.min(element.offsetWidth, element.offsetHeight);
-      const borderColor = getColor(border, colorUtils.getFadedColor(backgroundColor), theme);
+      const borderColor = colorUtils.getColor(border, colorUtils.getFadedColor(backgroundColor), theme);
       const borderSize = ((border.width || DEFAULTS.BORDER_WIDTH) * lengthShortSide) / 2;
       styles += formatProperty('border', `${borderSize}px solid ${borderColor}`);
       styles += formatProperty(

--- a/src/utils/style-utils.js
+++ b/src/utils/style-utils.js
@@ -1,4 +1,4 @@
-const FONT_FAMILIES = [
+export const FONT_FAMILIES = [
   'American Typewriter, serif',
   'Andalé Mono, monospace',
   'Arial Black, sans-serif',
@@ -20,6 +20,36 @@ const FONT_FAMILIES = [
   'Trebuchet MS, sans-serif',
   'Verdana, sans-serif',
 ];
+
+export const backgroundSize = {
+  auto: 'auto auto',
+  alwaysFit: 'contain',
+  fitWidth: '100% auto',
+  fitHeight: 'auto 100%',
+  fill: '100% 100%',
+  alwaysFill: 'cover',
+};
+
+export const backgroundPosition = {
+  'top-left': 'top left',
+  'center-left': 'center left',
+  'bottom-left': 'bottom left',
+  'top-center': 'top center',
+  'center-center': 'center center',
+  'bottom-center': 'bottom center',
+  'top-right': 'top right',
+  'center-right': 'center right',
+  'bottom-right': 'bottom right',
+  topLeft: '0% 0%', // top left
+  centerLeft: '50% 0%', // center left
+  bottomLeft: '100% 0%', // bottom left
+  topCenter: '0% 50%', // top center
+  centerCenter: '50% 50%', // center center
+  bottomCenter: '100% 50%', // bottom center
+  topRight: '0% 100%', // top right
+  centerRight: '50% 100%', // center right
+  bottomRight: '100% 100%', // bottom right
+};
 
 export const colorOptions = [
   {


### PR DESCRIPTION
The background and border styling options have been added to the action-button chart styling panel, it includes the listed items.  

- Background color
- Background Image using MediaLibrary
- Border
- Reset the section

Feature-flag: SENSECLIENT_IM_1525_STYLINGPANEL_BUTTON
Note: To be able to test it locally, sense-client needs to be linked to analytic changes on my branch https://github.com/qlik-trial/analytics/pull/401 and for getting new translations to https://github.com/qlik-trial/sense-client/pull/23139

Unsolved Issues of the current PR:

- Color Picker preview boxes are not showing the default colors that should be fixed in the coming PRs.
- The position grid does not show focus on center at the beginning. It is because the old and new version of positionGrid component take different values for the default position. The current value is `centerCenter` whereas it is 'center-center' with the new component. 

https://user-images.githubusercontent.com/20701546/219906767-1bd6c05c-8334-4962-8fe2-adcfafdacf49.mp4
