### PR TITLE
feat: set default props

### DIFF
--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -54,6 +54,8 @@ const properties = {
   navigation: {
     action: 'none',
   },
+  disableNavMenu: true,
+  showDetails: false,
   /**
    * All styling options
    * @type {Style}


### PR DESCRIPTION
Sets the default values of:
- showDetails: false - hides the show detaisl option as it isn't relevant
- disableNavMenu: true - disables the navigation menu