### PR TITLE
fix: changing mode from media to none deletes the url value

### DIFF
--- a/src/styling-panel-definition.js
+++ b/src/styling-panel-definition.js
@@ -132,9 +132,8 @@ export const getStyleEditorDefinition = () => ({
               ],
               change(data) {
                 const bgImageComp = data.style.background;
-                bgImageComp
-                  ? (bgImageComp.url = { qStaticContentUrlDef: '' })
-                  : (data.style.background = { url: { qStaticContentUrlDef: '' } });
+                if (!bgImageComp) data.style.background = { qStaticContentUrlDef: {} };
+                if (!bgImageComp.url) data.style.background.url = {};
               },
             },
             MediaLibrary: {
@@ -174,8 +173,8 @@ export const getStyleEditorDefinition = () => ({
                 },
               ],
               change: (data) => {
-                let currentPosition = propertyResolver.getValue(data, 'style.background.position');
-                if (currentPosition) currentPosition = styleDefaults.BGIMAGE_POSITION;
+                if (propertyResolver.getValue(data, 'style.background.position'))
+                  data.style.background.position = styleDefaults.BGIMAGE_POSITION;
               },
               show: (data) =>
                 propertyResolver.getValue(data, 'style.background.mode') === 'media' &&

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -1,5 +1,6 @@
 import styleFormatter from '../style-formatter';
 import defaultValues from '../../__tests__/default-button-props';
+import { getStyleEditorDefinition } from '../../styling-panel-definition';
 
 describe('style-formatter', () => {
   describe('getStyles', () => {
@@ -24,7 +25,7 @@ describe('style-formatter', () => {
       const d = defaultValues();
       theme = d.theme;
       layout = d.layout;
-      style = JSON.parse(JSON.stringify(layout.style));
+      style = layout.style;
       element = {
         offsetHeight: 200,
         offsetWidth: 100,
@@ -98,15 +99,6 @@ describe('style-formatter', () => {
       expect(formattedStyle.includes('background-color: myPrimaryColor')).toBe(true);
     });
 
-    it('should not return specified image url when the background mode is set on none', () => {
-      style.background.useImage = false;
-      style.background.mode = 'none';
-      const formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
-      expect(formattedStyle.includes('background-size: auto auto')).toBe(false);
-      expect(formattedStyle.includes('background-position: 50% 50%')).toBe(false);
-      expect(formattedStyle.includes('background-repeat: no-repeat')).toBe(false);
-    });
-
     it('should return specified image url when the background mode is set on media', () => {
       style.background.useImage = false;
       style.background.mode = 'media';
@@ -127,6 +119,27 @@ describe('style-formatter', () => {
       expect(formattedStyle.includes('background-size:')).toBe(false);
       expect(formattedStyle.includes('background-position:')).toBe(false);
       expect(formattedStyle.includes('background-repeat:')).toBe(false);
+    });
+
+    it('should keep the image url but not show it when the mode changes from media to none', () => {
+      const { backgroundImageMode } = getStyleEditorDefinition().items.backgroundOptions.items.backgroundImage.items;
+
+      style.background.useImage = false;
+      style.background.mode = 'media';
+      style.background.url.qStaticContentUrl = { qUrl: someUrl };
+      let formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes('background-image:')).toBe(true);
+
+      style.background.mode = 'none';
+      backgroundImageMode.change(layout);
+      expect(style.background.url.qStaticContentUrl.qUrl).toEqual('/media/Logo/qlik.png');
+      formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes('background-image:')).toBe(false);
+
+      style.background.mode = 'media';
+      backgroundImageMode.change(layout);
+      formattedStyle = styleFormatter.getStyles({ style, disabled, theme, app });
+      expect(formattedStyle.includes('background-image:')).toBe(true);
     });
 
     it('should return specified image url and default image settings', () => {


### PR DESCRIPTION
This PR fixed the issue of 
- Changing the mode from 'media' to 'none', the background image URL will be deleted. However, the URL should only be deleted if the panel section is reset.