### PR TITLE
fix: copy block, user id and prop hiding updates

### DIFF
--- a/src/utils/__tests__/actions.spec.js
+++ b/src/utils/__tests__/actions.spec.js
@@ -22,7 +22,6 @@ describe('actions', () => {
   const id = 'fakeId';
   const sheetId = 'fakeSheetId';
   const senseNavigation = { getCurrentSheetId: () => sheetId };
-  const subject = 'fakeSubject';
   const tenantId = 'fakeTenantId';
   const spaceId = 'fakeSpaceId';
   const csrfToken = 'fakeCsrfToken';
@@ -85,7 +84,6 @@ describe('actions', () => {
             automationExecutionToken,
             inputs,
             blocks,
-            subject,
             tenantId,
             headers: { get: () => csrfToken },
             attributes: { spaceId },
@@ -368,7 +366,7 @@ describe('actions', () => {
         body: JSON.stringify({
           app: appId,
           sheet: sheetId,
-          user: subject,
+          user: id,
           space: spaceId,
           tenant: tenantId,
           time,
@@ -410,7 +408,7 @@ describe('actions', () => {
         inputs: {
           app: app.id,
           sheet: sheetId,
-          user: subject,
+          user: id,
           space: spaceId,
           tenant: tenantId,
           time,

--- a/src/utils/__tests__/automation-helper.spec.js
+++ b/src/utils/__tests__/automation-helper.spec.js
@@ -14,7 +14,7 @@ describe('automation helper', () => {
   const csrfToken = 'fakeCsrfToken';
   const spaceId = 'fakeSpaceId';
   const sheetId = 'fakeSheetId';
-  const subject = 'fakeSubject';
+  const userId = 'fakeUserId';
   const tenantId = 'fakeTenantId';
   const automationId = 'fakeAutomationId';
   const automationExecutionToken = 'fakeExecutionToken';
@@ -24,7 +24,7 @@ describe('automation helper', () => {
     inputs: {
       app: app.id,
       sheet: sheetId,
-      user: subject,
+      user: userId,
       space: spaceId,
       tenant: tenantId,
       time: new Date(),
@@ -46,7 +46,7 @@ describe('automation helper', () => {
         Promise.resolve({
           json: () => ({
             attributes: { spaceId },
-            subject,
+            id: userId,
             tenantId,
             guid: automationId,
             status,

--- a/src/utils/automation-helper.js
+++ b/src/utils/automation-helper.js
@@ -384,7 +384,7 @@ export const getAutomationData = async ({ app, automationId, bookmark, senseNavi
     app: app.id,
     bookmark,
     sheet: senseNavigation?.getCurrentSheetId(),
-    user: user.subject,
+    user: user.id,
     space: await getSpaceId(app.id),
     tenant: user.tenantId,
     time: new Date(),
@@ -516,7 +516,7 @@ export const getInputBlocks = (bookmark) => {
       childId: null,
       inputs: [
         { id: 'd41ae430-073a-11ec-bdef-bb104839c843', value: '{$.inputs.app}', type: 'string', structure: [] },
-        { id: 'fab02320-9270-11ed-a391-739edffdb33c', value: '{$.inputs.bookmark}', type: 'string', structure: [] },
+        { id: 'd41b7e40-073a-11ec-ac1b-59270c518ae7', value: '{$.inputs.bookmark}', type: 'string', structure: [] },
         {
           id: 'f478e320-9270-11ed-b551-d73ebe8e14ad',
           value: 'Yes',

--- a/src/utils/automation-props.js
+++ b/src/utils/automation-props.js
@@ -58,7 +58,7 @@ const getAutomationProps = (multiUserAutomation, getAutomations) => ({
   includeSelectionsText: {
     translation: `Object.ActionButton.Automation.SendSelectionsHelp`,
     component: 'text',
-    show: (data) => data.automationPostData && multiUserAutomation,
+    show: () => multiUserAutomation,
   },
   automationTriggered: {
     type: 'boolean',
@@ -78,7 +78,7 @@ const getAutomationProps = (multiUserAutomation, getAutomations) => ({
   automationTriggeredText: {
     translation: `Object.ActionButton.Automation.RunModeTriggeredHelp`,
     component: 'text',
-    show: (data) => multiUserAutomation && data.automationTriggered,
+    show: () => multiUserAutomation,
   },
   automationShowNotification: {
     ref: 'automationShowNotification',


### PR DESCRIPTION
**Automation action:**
- Fixed a bug with the copy block button which was causing the bookmark id to not be populated correctly when pasting it into an automation
- Instead of sending the identity provider subject in the user field of the payload to the automation, we are now sending the user id. This is based on feedback from presales
- 2 helper texts were previously only displaying in the properties after setting the property to true - these are now set to always display based on feedback from the automation team