### PR TITLE
feat: add font size behavior dropdown

### DIFF
--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -68,6 +68,7 @@ const properties = {
       color: DEFAULTS.FONT_COLOR,
       colorExpression: '',
       size: DEFAULTS.FONT_SIZE,
+      sizeBehavior: DEFAULTS.SIZE_BEHAVIOR,
       style: DEFAULTS.FONT_STYLE,
       align: DEFAULTS.TEXT_ALIGN,
     },
@@ -158,6 +159,7 @@ const properties = {
  * @property {boolean=} [style.bold = true] - Bold text
  * @property {boolean=} [style.italic = false] - Italic text
  * @property {boolean=} [style.underline = false] - Underlined text
+ * @property {('responsive'|'fluid'|'fixed')} [sizeBehavior='responsive'] - Setting to determine how the fontsize of the label is calculated.
  */
 
 /**

--- a/src/style-defaults.js
+++ b/src/style-defaults.js
@@ -4,6 +4,7 @@ export default {
   FONT_COLOR: { index: -1, color: '#ffffff' },
   FONT_STYLE: { bold: true, italic: false, underline: false },
   FONT_FAMILY: 'Source Sans Pro',
+  SIZE_BEHAVIOR: 'responsive',
   TEXT_ALIGN: 'center',
   COLOR: { index: -1, color: 'none' },
   ICON_POSITION: 'left',

--- a/src/styling-panel-definition.js
+++ b/src/styling-panel-definition.js
@@ -1,6 +1,6 @@
 import styleDefaults from './style-defaults';
 import propertyResolver from './utils/property-resolver';
-import { fontFamilyOptions, colorOptions, toggleOptions } from './utils/style-utils';
+import { fontFamilyOptions, colorOptions, toggleOptions, fontSizeOptions } from './utils/style-utils';
 
 export const getStyleEditorDefinition = () => ({
   items: {
@@ -34,6 +34,13 @@ export const getStyleEditorDefinition = () => ({
                   defaultValue: styleDefaults.TEXT_ALIGN,
                 },
               },
+            },
+            fontSizeBehavior: {
+              component: 'dropdown',
+              ref: 'style.font.sizeBehavior',
+              translation: 'properties.kpi.layoutBehavior',
+              defaultValue: 'responsive',
+              options: fontSizeOptions,
             },
             fontSize: {
               component: 'slider',

--- a/src/utils/__tests__/style-utils.spec.js
+++ b/src/utils/__tests__/style-utils.spec.js
@@ -1,0 +1,54 @@
+import { setTextFontSize } from '../style-utils';
+
+describe('setTextFontSize function', () => {
+  let text;
+  let font;
+  let textFontSize;
+  let hasIcon;
+
+  beforeEach(() => {
+    text = {
+      style: { fontSize: '12px' },
+      offsetWidth: '20',
+      children: [
+        {
+          style: { marginRight: '0px' },
+        },
+        {
+          style: { marginRight: '0px' },
+        },
+      ],
+    };
+    font = { style: { italic: true } };
+    textFontSize = 12;
+    hasIcon = true;
+  });
+
+  it('should set font size and margins for italic font with icon', () => {
+    setTextFontSize(text, font, textFontSize, hasIcon);
+    expect(text.style.fontSize).toBe('10.08px');
+    expect(text.children[0].style.marginRight).toBe('0.80px');
+    expect(text.children[1].style.marginRight).toBe('0.80px');
+  });
+
+  it('should set font size and margins for italic font without icon', () => {
+    hasIcon = false;
+    setTextFontSize(text, font, textFontSize, hasIcon);
+    expect(text.style.fontSize).toBe('10.80px');
+    expect(text.children[0].style.marginRight).toBe('0.40px');
+  });
+
+  it('should set font size and margins for non-italic font with icon', () => {
+    font.style.italic = false;
+    setTextFontSize(text, font, textFontSize, hasIcon);
+    expect(text.style.fontSize).toBe('10.56px');
+    expect(text.children[0].style.marginRight).toBe('0.80px');
+  });
+
+  it('should set font size for non-italic font without icon', () => {
+    hasIcon = false;
+    font.style.italic = false;
+    setTextFontSize(text, font, textFontSize, hasIcon);
+    expect(text.style.fontSize).toBe('11.04px');
+  });
+});

--- a/src/utils/style-utils.js
+++ b/src/utils/style-utils.js
@@ -73,8 +73,43 @@ export const toggleOptions = [
   },
 ];
 
+export const fontSizeOptions = [
+  {
+    value: 'responsive',
+    translation: 'properties.responsive',
+  },
+  {
+    value: 'fixed',
+    translation: 'properties.fixed',
+  },
+  {
+    value: 'fluid',
+    translation: 'properties.fluid',
+  },
+];
+
 const getFirstFont = (s) => s.split(',')[0];
 export const fontFamilyOptions = FONT_FAMILIES.map((font) => ({
   value: font,
   label: getFirstFont(font),
 }));
+
+const trimDecimal = (num) => (num % 1 !== 0 ? num.toFixed(2) : num);
+
+export const setTextFontSize = (text, font, textFontSize, hasIcon) => {
+  if (font.style && font.style.italic) {
+    if (hasIcon) {
+      text.style.fontSize = `${trimDecimal(Math.max(textFontSize * 0.84, 8))}px`;
+      text.children[0].style.marginRight = `${trimDecimal(text.offsetWidth * 0.04)}px`;
+      text.children[1].style.marginRight = `${trimDecimal(text.offsetWidth * 0.04)}px`;
+    } else {
+      text.style.fontSize = `${trimDecimal(Math.max(textFontSize * 0.9, 8))}px`;
+      text.children[0].style.marginRight = `${trimDecimal(text.offsetWidth * 0.02)}px`;
+    }
+  } else if (hasIcon) {
+    text.style.fontSize = `${trimDecimal(Math.max(textFontSize * 0.88, 8))}px`;
+    text.children[0].style.marginRight = `${trimDecimal(text.offsetWidth * 0.04)}px`;
+  } else {
+    text.style.fontSize = `${trimDecimal(Math.max(textFontSize * 0.92, 8))}px`;
+  }
+};

--- a/test/rendering/__fixtures__/scenario_1.fix.js
+++ b/test/rendering/__fixtures__/scenario_1.fix.js
@@ -31,6 +31,7 @@ export default () => ({
           label: 'Button',
           font: {
             size: 0.46,
+            sizeBehavior: 'responsive',
             useColorExpression: false,
             color: {
               index: 8,


### PR DESCRIPTION
This PR is mostly based on @niekvanstaveren and @a-m-dev developments of font size behavior. [#312](https://github.com/qlik-oss/sn-action-button/pull/312), [#331](https://github.com/qlik-oss/sn-action-button/pull/331)
The font size behavior drop down is added which provides three options of `responsive`, `fluid `and `fixed `font scaling.

**Options definitions:**
- **Fixed** in which the font size is independent of the box size and the length of the text
- **Fluid** in which the font size adapts to the size of the box
- **Responsive** in which the font size adapts to the size of the box and the length of text.