### PR TITLE
feat: add font size input box to labelSection

### DIFF
--- a/src/__tests__/styling-panel-definition.spec.js
+++ b/src/__tests__/styling-panel-definition.spec.js
@@ -1,0 +1,26 @@
+import { getStylingPanelDefinition } from '../styling-panel-definition';
+import objectProperties from '../object-properties';
+
+describe('getStylingPanelDefinition', () => {
+  let data;
+  const props = getStylingPanelDefinition();
+  const { labelItem } = props.items.styleEditor.items.labelSection.items;
+
+  describe('show functions', () => {
+    beforeEach(() => {
+      data = JSON.parse(JSON.stringify(objectProperties));
+    });
+
+    it('should return true for fontSize and false for fontSizeFixed when relative font size', () => {
+      data.style.font.sizeBehavior = 'relative';
+      expect(labelItem.items.fontSize.show(data)).toBe(true);
+      expect(labelItem.items.fontSizeFixed.show(data)).toBe(false);
+    });
+
+    it('should return false for fontSize and true for fontSizeFixed when fixed font size', () => {
+      data.style.font.sizeBehavior = 'fixed';
+      expect(labelItem.items.fontSize.show(data)).toBe(false);
+      expect(labelItem.items.fontSizeFixed.show(data)).toBe(true);
+    });
+  });
+});

--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -68,6 +68,7 @@ const properties = {
       color: DEFAULTS.FONT_COLOR,
       colorExpression: '',
       size: DEFAULTS.FONT_SIZE,
+      sizeFixed: DEFAULTS.FONT_SIZE_FIXED,
       sizeBehavior: DEFAULTS.SIZE_BEHAVIOR,
       style: DEFAULTS.FONT_STYLE,
       align: DEFAULTS.TEXT_ALIGN,
@@ -154,6 +155,7 @@ const properties = {
  * @property {PaletteColor=} color - Color defined by index or hex code, needed if useColorExpression is false
  * @property {ColorExpression=} colorExpression - Color defined by expression, needed if useColorExpression is true
  * @property {number=} [size=0.5] - Relative[] size of label, must be greater than 0 and 1 fills the entire button
+ * @property {number=} [sizeFixed=20] - Fixed size of the label in pixels. Must be bigger than 5. Only active when sizeBehavior is fixed.
  * @property {('left'|'center'|'right')=} [align='center'] - Horizontal alignment
  * @property {object=} style - Additional style options
  * @property {boolean=} [style.bold = true] - Bold text

--- a/src/style-defaults.js
+++ b/src/style-defaults.js
@@ -1,6 +1,7 @@
 export default {
   LABEL: 'Button',
   FONT_SIZE: 0.5,
+  FONT_SIZE_FIXED: 20,
   FONT_COLOR: { index: -1, color: '#ffffff' },
   FONT_STYLE: { bold: true, italic: false, underline: false },
   FONT_FAMILY: 'Source Sans Pro',

--- a/src/styling-panel-definition.js
+++ b/src/styling-panel-definition.js
@@ -1,6 +1,6 @@
 import styleDefaults from './style-defaults';
 import propertyResolver from './utils/property-resolver';
-import { fontFamilyOptions, colorOptions, toggleOptions, fontSizeOptions } from './utils/style-utils';
+import { fontFamilyOptions, colorOptions, toggleOptions, sizeBehaviorOptions } from './utils/style-utils';
 
 export const getStyleEditorDefinition = () => ({
   items: {
@@ -40,7 +40,7 @@ export const getStyleEditorDefinition = () => ({
               ref: 'style.font.sizeBehavior',
               translation: 'properties.kpi.layoutBehavior',
               defaultValue: 'responsive',
-              options: fontSizeOptions,
+              options: sizeBehaviorOptions,
             },
             fontSize: {
               component: 'slider',
@@ -51,6 +51,17 @@ export const getStyleEditorDefinition = () => ({
               max: 1,
               step: 0.01,
               defaultValue: 0.5,
+              show: (data) => !(propertyResolver.getValue(data, 'style.font.sizeBehavior') === 'fixed'),
+            },
+            fontSizeFixed: {
+              type: 'number',
+              ref: 'style.font.sizeFixed',
+              component: 'integer',
+              translation: 'properties.fontSize',
+              min: 5,
+              defaultValue: 20,
+              option: 'optional',
+              show: (data) => propertyResolver.getValue(data, 'style.font.sizeBehavior') === 'fixed',
             },
             fontColor: {
               items: {

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -430,28 +430,23 @@ describe('style-formatter', () => {
       });
 
       describe('fixed', () => {
-        it('adjusts font size to the layout font size', () => {
-          expect(style.font.size).toBe(0.5);
+        it('adjusts font size to the layout default font size', () => {
           style.font.sizeBehavior = 'fixed';
           styleFormatter.createLabelAndIcon({ theme, button, style });
-          expect(button.children[0].style.fontSize).toBe('46px');
+          expect(button.children[0].style.fontSize).toBe('20px');
           style.font.size = 0.6;
           styleFormatter.createLabelAndIcon({ theme, button, style });
-          expect(button.children[1].style.fontSize).toBe('55.20px');
+          expect(button.children[1].style.fontSize).toBe('20px');
         });
 
         it('adjusts font size to the layout font size, none of the button or text length is considered', () => {
-          expect(style.font.size).toBe(0.5);
           style.font.sizeBehavior = 'fixed';
-          button.clientWidth = 100;
-          button.clientHeight = 50;
-          styleFormatter.createLabelAndIcon({ theme, button, style });
-          expect(button.children[0].style.fontSize).toBe('46px');
+          style.font.sizeFixed = 16;
           // change the button client sizes
           button.clientWidth = 50;
           button.clientHeight = 100;
           styleFormatter.createLabelAndIcon({ theme, button, style });
-          expect(button.children[1].style.fontSize).toBe('46px');
+          expect(button.children[0].style.fontSize).toBe('16px');
           // change the text offset sizes
           button.appendChild = (child) => {
             child.setAttribute = jest.fn();
@@ -460,7 +455,7 @@ describe('style-formatter', () => {
             button.children.push(child);
           };
           styleFormatter.createLabelAndIcon({ theme, button, style });
-          expect(button.children[2].style.fontSize).toBe('46px');
+          expect(button.children[1].style.fontSize).toBe('16px');
         });
       });
     });

--- a/src/utils/style-utils.js
+++ b/src/utils/style-utils.js
@@ -75,7 +75,7 @@ export const toggleOptions = [
   },
 ];
 
-export const fontSizeOptions = [
+export const sizeBehaviorOptions = [
   {
     value: 'responsive',
     translation: 'properties.responsive',
@@ -119,8 +119,7 @@ export const setTextFontSize = (text, font, textFontSize, hasIcon) => {
 export const adjustFontSizeBehavior = (button, font, text, textSpan, hasIcon) => {
   if (font.sizeBehavior === 'fixed') {
     // The font size is independent of the box size and the length of the text
-    const textFontSize = (font.size || DEFAULTS.FONT_SIZE) * 100;
-    setTextFontSize(text, font, textFontSize, hasIcon);
+    text.style.fontSize = `${font.sizeFixed || DEFAULTS.FONT_SIZE_FIXED}px`;
     textSpan.style.overflow = 'hidden';
   } else if (font.sizeBehavior === 'relative') {
     const layoutFontSize = font.size || DEFAULTS.FONT_SIZE;


### PR DESCRIPTION
Adding the input box to insert an exact font size in px when the action button size behavior is set on `fixed` mode. 
The code is almost the same code @niekvanstaveren has been committed here: #312 


https://user-images.githubusercontent.com/20701546/231479760-21bda4ac-5419-417c-835a-1b6a75ea833c.mp4
