### PR TITLE
fix: make sure bookmark layout gets applied to app

### DIFF
--- a/src/utils/__tests__/actions.spec.js
+++ b/src/utils/__tests__/actions.spec.js
@@ -70,7 +70,19 @@ describe("actions", () => {
         getVariableByName: jest.fn(() => Promise.resolve(variableObject)),
         lockAll: jest.fn(),
         unlockAll: jest.fn(),
-        getBookmarkList: () => [{ qData: { title: "findMyBookmark" }, qInfo: { qId: "myBookmarkId" } }],
+        clearAllSoftPatches: jest.fn(),
+        getBookmarkList: () => [
+          {
+            qData: { title: "findMyBookmark" },
+            qInfo: { qId: "myBookmarkId" },
+            qMeta: { isExtended: false },
+          },
+          {
+            qData: { title: "findMyBookmarkExtended" },
+            qInfo: { qId: "myBookmarkExtendedId" },
+            qMeta: { isExtended: true },
+          },
+        ],
         evaluate: () => "43850;43881",
         doReload: jest.fn(() => true),
         doSave: jest.fn(),
@@ -116,6 +128,18 @@ describe("actions", () => {
       const actionObj = actions.find((action) => action.value === "applyBookmark");
       await actionObj.getActionCall({ app, bookmark: "findMyBookmark" })();
       expect(app.applyBookmark).toHaveBeenCalledWith("myBookmarkId");
+    });
+
+    it("should call clearallsoftpatches if bookmark is extended", async () => {
+      const actionObj = actions.find((action) => action.value === "applyBookmark");
+      await actionObj.getActionCall({ app, bookmark: "myBookmarkExtendedId" })();
+      expect(app.clearAllSoftPatches).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call clearallsoftpatches if bookmark is not extended", async () => {
+      const actionObj = actions.find((action) => action.value === "applyBookmark");
+      await actionObj.getActionCall({ app, bookmark: "myBookmarkId" })();
+      expect(app.clearAllSoftPatches).toHaveBeenCalledTimes(0);
     });
 
     it("should call back", async () => {

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -33,6 +33,10 @@ const actions = [
       ({ app, bookmark }) =>
       async () => {
         const bookMarks = await app.getBookmarkList();
+        const findBmWithID = bookMarks.find((bm) => bm.qInfo.qId === bookmark);
+        if (findBmWithID.qData.qBookmark.qPatches.length > 0 || findBmWithID.qMeta.isExtended) {
+          app.clearAllSoftPatches();
+        }
         const findBm = bookMarks.find((bm) => bm.qData.title === bookmark);
         bookmark && (await app.applyBookmark((findBm && findBm.qInfo && findBm.qInfo.qId) || bookmark));
       },

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -35,7 +35,7 @@ const actions = [
         const bookMarks = await app.getBookmarkList();
         const findBmWithID = bookMarks.find((bm) => bm.qInfo.qId === bookmark);
         if (findBmWithID.qData.qBookmark.qPatches.length > 0 || findBmWithID.qMeta.isExtended) {
-          app.clearAllSoftPatches();
+          app.clearAllSoftPatches?.();
         }
         const findBm = bookMarks.find((bm) => bm.qData.title === bookmark);
         bookmark && (await app.applyBookmark((findBm && findBm.qInfo && findBm.qInfo.qId) || bookmark));

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -34,8 +34,8 @@ const actions = [
       async () => {
         const bookMarks = await app.getBookmarkList();
         const findBmWithID = bookMarks.find((bm) => bm.qInfo.qId === bookmark);
-        if (findBmWithID.qData.qBookmark.qPatches.length > 0 || findBmWithID.qMeta.isExtended) {
-          app.clearAllSoftPatches?.();
+        if (findBmWithID?.qData?.qBookmark?.qPatches?.length > 0 || findBmWithID?.qMeta?.isExtended) {
+          await app.clearAllSoftPatches?.();
         }
         const findBm = bookMarks.find((bm) => bm.qData.title === bookmark);
         bookmark && (await app.applyBookmark((findBm && findBm.qInfo && findBm.qInfo.qId) || bookmark));


### PR DESCRIPTION
Before when activating a bookmark through action button, a layout wouldnt be applied if there was one before. Now we check if the bookmark we want to use has a layout and if it does we remove all previous layout so the new one can be applied.

Tested on localhost.