### PR TITLE
feat: add showLabel toggle so that label can be hidden (a11y)

### DIFF
--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -790,6 +790,12 @@
           "defaultValue": "'Button'",
           "type": "string"
         },
+        "showLabel": {
+          "description": "If the label should be shown or hidden",
+          "optional": true,
+          "defaultValue": true,
+          "type": "boolean"
+        },
         "font": {
           "description": "Styling for the label",
           "optional": true,

--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -790,12 +790,6 @@
           "defaultValue": "'Button'",
           "type": "string"
         },
-        "showLabel": {
-          "description": "If the label should be shown or hidden",
-          "optional": true,
-          "defaultValue": true,
-          "type": "boolean"
-        },
         "font": {
           "description": "Styling for the label",
           "optional": true,

--- a/src/ext.js
+++ b/src/ext.js
@@ -295,11 +295,24 @@ export default function ext({ translator, shouldHide, senseNavigation }) {
                 cellNavMenu: {
                   show: false,
                 },
-                label: {
-                  component: "string",
-                  ref: "style.label",
-                  translation: "Common.Label",
-                  expression: "optional",
+                labelGroup: {
+                  type: "items",
+                  items: {
+                    label: {
+                      component: "string",
+                      ref: "style.label",
+                      translation: "Common.Label",
+                      expression: "optional",
+                    },
+                    showLabelToggle: {
+                      component: "switch",
+                      type: "boolean",
+                      ref: "style.showLabel",
+                      translation: "properties.referenceLines.showLabel",
+                      defaultValue: true,
+                      options: toggleOptions,
+                    },
+                  },
                 },
               },
             },

--- a/src/object-properties.js
+++ b/src/object-properties.js
@@ -62,6 +62,7 @@ const properties = {
    */
   style: {
     label: DEFAULTS.LABEL,
+    showLabel: true,
     font: {
       fontFamily: DEFAULTS.FONT_FAMILY,
       useColorExpression: false,
@@ -142,6 +143,7 @@ const properties = {
  * Holds styling options
  * @typedef {object} Style
  * @property {string=} [label='Button'] - The text displayed on the button
+ * @property {boolean=} [showLabel=true] - If the label should be shown or hidden
  * @property {Font=} font - Styling for the label
  * @property {Background=} background - Styling for background, including image
  * @property {Border=} border - Styling for border

--- a/src/utils/__tests__/style-formatter.spec.js
+++ b/src/utils/__tests__/style-formatter.spec.js
@@ -393,6 +393,15 @@ describe("style-formatter", () => {
           expect(text.children[1].textContent).toEqual("Button");
           expect(button.children[0].style.fontSize).toEqual("10.50px");
         });
+
+        it("should hide label when showLabel is false", () => {
+          style.showLabel = false;
+          styleFormatter.createLabelAndIcon({ theme, button, style });
+          const text = button.children[0];
+          expect(text.style.height).toEqual("1px");
+          expect(text.style.width).toEqual("1px");
+          expect(text.style.overflow).toEqual("hidden");
+        });
       });
 
       describe("relative", () => {

--- a/src/utils/style-formatter.js
+++ b/src/utils/style-formatter.js
@@ -61,7 +61,6 @@ export default {
     const textSpan = document.createElement("span");
     textSpan.textContent = label;
     font.style && font.style.underline && (textSpan.style.textDecoration = "underline");
-
     text.appendChild(textSpan);
     // icon
     const hasIcon = isSense && icon.useIcon && icon.iconType !== "";

--- a/src/utils/style-formatter.js
+++ b/src/utils/style-formatter.js
@@ -53,7 +53,7 @@ export default {
     return styles;
   },
   createLabelAndIcon({ button, theme, style = {}, isSense }) {
-    const { icon = {}, font = {}, label = DEFAULTS.LABEL } = style;
+    const { icon = {}, font = {}, label = DEFAULTS.LABEL, showLabel = true } = style;
     // text element wrapping label and icon
     const text = document.createElement("text");
     text.style.fontFamily = style.font.fontFamily || theme.getStyle("", "", "fontFamily") || DEFAULTS.FONT_FAMILY;
@@ -61,6 +61,7 @@ export default {
     const textSpan = document.createElement("span");
     textSpan.textContent = label;
     font.style && font.style.underline && (textSpan.style.textDecoration = "underline");
+
     text.appendChild(textSpan);
     // icon
     const hasIcon = isSense && icon.useIcon && icon.iconType !== "";
@@ -86,5 +87,10 @@ export default {
     text.style.display = "flex";
     text.style.alignItems = "center";
     text.style.justifyContent = font.align === "left" ? "flex-start" : font.align === "right" ? "flex-end" : "center";
+    if (!showLabel) {
+      text.style.height = "1px";
+      text.style.width = "1px";
+      text.style.overflow = "hidden";
+    }
   },
 };


### PR DESCRIPTION
![Screenshot 2023-05-24 at 13 35 32](https://github.com/qlik-oss/sn-action-button/assets/26596242/0a28bad2-f4d0-4f01-941d-1aeb1d00efc5)
![Screenshot 2023-05-24 at 13 35 21](https://github.com/qlik-oss/sn-action-button/assets/26596242/da3ee42b-febd-48d6-8027-65e01411e11f)
Adding a toggle so that the button label can be hidden while still set to a text - this text is then available to screen readers