### PR TITLE
fix: remove unsupported softLock actions

### DIFF
--- a/src/utils/__tests__/actions.spec.js
+++ b/src/utils/__tests__/actions.spec.js
@@ -162,9 +162,9 @@ describe("actions", () => {
 
     it("should call clearAllButThis", async () => {
       const actionObject = actions.find((action) => action.value === "clearAllButThis");
-      await actionObject.getActionCall({ app, qStateName, field, softLock })();
+      await actionObject.getActionCall({ app, qStateName, field })();
       expect(app.getField).toHaveBeenCalledWith(field, qStateName);
-      expect(fieldObject.clearAllButThis).toHaveBeenCalledWith(softLock);
+      expect(fieldObject.clearAllButThis).toHaveBeenCalledWith(false);
     });
 
     it("should NOT call clearAllButThis when no field", async () => {
@@ -204,9 +204,9 @@ describe("actions", () => {
 
     it("should call toggleSelect", async () => {
       const actionObject = actions.find((action) => action.value === "toggleSelect");
-      await actionObject.getActionCall({ app, qStateName, field, value, softLock })();
+      await actionObject.getActionCall({ app, qStateName, field, value })();
       expect(app.getField).toHaveBeenCalledWith(field, qStateName);
-      expect(fieldObject.toggleSelect).toHaveBeenCalledWith(value, softLock);
+      expect(fieldObject.toggleSelect).toHaveBeenCalledWith(value, false);
     });
 
     it("should NOT call toggleSelect when no field", async () => {
@@ -233,8 +233,8 @@ describe("actions", () => {
 
     it("should call selectMatchingValues", async () => {
       const actionObject = actions.find((action) => action.value === "selectMatchingValues");
-      await actionObject.getActionCall({ app, qStateName, field, value, softLock })();
-      expect(fieldObject.select).toHaveBeenCalledWith(value, false, softLock);
+      await actionObject.getActionCall({ app, qStateName, field, value })();
+      expect(fieldObject.select).toHaveBeenCalledWith(value, false, false);
     });
 
     it("should NOT call selectMatchingValues when no field", async () => {
@@ -274,9 +274,9 @@ describe("actions", () => {
 
     it("should call selectPossible", async () => {
       const actionObject = actions.find((action) => action.value === "selectPossible");
-      await actionObject.getActionCall({ app, qStateName, field, softLock })();
+      await actionObject.getActionCall({ app, qStateName, field })();
       expect(app.getField).toHaveBeenCalledWith(field, qStateName);
-      expect(fieldObject.selectPossible).toHaveBeenCalledWith(softLock);
+      expect(fieldObject.selectPossible).toHaveBeenCalledWith(false);
     });
 
     it("should NOT call selectPossible when no field", async () => {

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -80,14 +80,15 @@ const actions = [
     translation: "Object.ActionButton.ClearAllButThis",
     group: "selection",
     getActionCall:
-      ({ app, qStateName, field, softLock }) =>
+      ({ app, qStateName, field }) =>
       async () => {
         if (field) {
           const fieldObj = await app.getField(field, qStateName);
+          const softLock = false;
           await fieldObj.clearAllButThis(softLock);
         }
       },
-    requiredInput: ["field", "softLock"],
+    requiredInput: ["field"],
   },
   {
     value: "clearField",
@@ -138,14 +139,15 @@ const actions = [
     translation: "Object.ActionButton.SelectMatchingValues",
     group: "selection",
     getActionCall:
-      ({ app, qStateName, field, value, softLock }) =>
+      ({ app, qStateName, field, value }) =>
       async () => {
         if (field && value) {
           const fieldObj = await app.getField(field, qStateName);
+          const softLock = false;
           await fieldObj.select(value, false, softLock);
         }
       },
-    requiredInput: ["field", "value", "softLock"],
+    requiredInput: ["field", "value"],
   },
   {
     value: "selectAlternative",
@@ -182,29 +184,31 @@ const actions = [
     translation: "Object.ActionButton.SelectPossibleValues",
     group: "selection",
     getActionCall:
-      ({ app, qStateName, field, softLock }) =>
+      ({ app, qStateName, field }) =>
       async () => {
         if (field) {
           const fieldObj = await app.getField(field, qStateName);
+          const softLock = false;
           await fieldObj.selectPossible(softLock);
         }
       },
     hide: ({ isFeatureBlacklisted }) => isFeatureBlacklisted?.("advancedSelectionOptions"),
-    requiredInput: ["field", "softLock"],
+    requiredInput: ["field"],
   },
   {
     value: "toggleSelect",
     translation: "Object.ActionButton.ToggleFieldSelection",
     group: "selection",
     getActionCall:
-      ({ app, qStateName, field, value, softLock }) =>
+      ({ app, qStateName, field, value }) =>
       async () => {
         if (field && value) {
           const fieldObj = await app.getField(field, qStateName);
+          const softLock = false;
           await fieldObj.toggleSelect(value, softLock);
         }
       },
-    requiredInput: ["field", "value", "softLock"],
+    requiredInput: ["field", "value"],
   },
   {
     value: "lockAll",


### PR DESCRIPTION
Remove actions which do no work with `softLock` (the checkbox label suggests that they should overwrite locked fields, but this does not work, which is also in accordance with Engine design).

I have gone through all actions and found that it works only for the following actions. For others I have removed the checkbox:
- clearAll
- selectAll
- selectAlternative
- selectExcluded
- selectValues

The same has been done in sense-client for sheet actions and this PR will make them aligned.

### Before:

<img width="244" alt="image" src="https://github.com/qlik-oss/sn-action-button/assets/5780544/b3c6db89-af9a-426d-a3d3-884db6d97d06">


### After (soft lock removed):

<img width="244" alt="image" src="https://github.com/qlik-oss/sn-action-button/assets/5780544/05cb6655-1fd3-4815-8228-f5d648aa9c80">
