### PR TITLE
fix: use fullscreen flag to disable fullscreen support

### DIFF
--- a/src/ext.js
+++ b/src/ext.js
@@ -669,6 +669,7 @@ export default function ext({ translator, shouldHide, senseNavigation, theme }) 
       snapshot: !1,
       viewData: !1,
       quickMobile: !0,
+      fullscreen: !1
     },
   };
 }

--- a/src/ext.js
+++ b/src/ext.js
@@ -664,12 +664,12 @@ export default function ext({ translator, shouldHide, senseNavigation, theme }) 
     importProperties,
     exportProperties: null,
     support: {
-      export: !1,
-      exportData: !1,
-      snapshot: !1,
-      viewData: !1,
-      quickMobile: !0,
-      fullscreen: !1
+      export: false,
+      exportData: false,
+      snapshot: false,
+      viewData: false,
+      quickMobile: true,
+      fullscreen: false,
     },
   };
 }


### PR DESCRIPTION
Use newly created fullscreen support prop to disable fullscreen support for this chart.
fullscreen support prop added here: https://github.com/qlik-trial/sense-client/pull/25161

Used by new line object (`sn-shape`) like so https://github.com/qlik-trial/sn-shape/pull/148

The prop removes the fullscreen option from the nav menu and the context menu.

Will create PR in sense-client to remove hardcoded checks for action-button and instead rely on the fullscreen support prop


Also changing booleans to actual booleans for readability.